### PR TITLE
[1.12.2] Add Comforts compatibility

### DIFF
--- a/src/main/java/com/therandomlabs/randomtweaks/base/CommonProxy.java
+++ b/src/main/java/com/therandomlabs/randomtweaks/base/CommonProxy.java
@@ -2,11 +2,13 @@ package com.therandomlabs.randomtweaks.base;
 
 import com.therandomlabs.randomtweaks.common.RTFoodStats;
 import com.therandomlabs.randomtweaks.common.RTLanguageMap;
+import com.therandomlabs.randomtweaks.common.SleepHandler;
 import com.therandomlabs.randomtweaks.common.world.WorldGeneratorOceanFloor;
 import com.therandomlabs.randomtweaks.common.world.WorldTypeRegistry;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+import net.minecraftforge.fml.common.event.FMLInterModComms;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.fml.common.registry.GameRegistry;
 
@@ -25,6 +27,10 @@ public class CommonProxy {
 
 		if(Loader.isModLoaded("applecore")) {
 			MinecraftForge.EVENT_BUS.register(new RTFoodStats.AppleCoreEventHandler());
+		}
+
+		if(Loader.isModLoaded("comforts")) {
+			FMLInterModComms.sendFunctionMessage("comforts", "mobSleepFilter", SleepHandler.MobFilter.class.getName());
 		}
 	}
 }


### PR DESCRIPTION
Hey Random, I'm the developer of the Comforts mod. I saw that your mod wasn't compatible with mine, so I tried to work out some sort of solution for that. Towards that effort, I've pushed out a new update of Comforts that has the IMC support that's integral to this pull request.

Basically, this PR will use IMC to communicate the additional filtering that RandomTweaks provides for mobs in the sleep check. Comforts will process this [here](https://github.com/TheIllusiveC4/Comforts/blob/c291625f9a0f638a6d5009032047ac1534d1ef76/src/main/java/c4/comforts/Comforts.java#L59-L67) and then [here](https://github.com/TheIllusiveC4/Comforts/blob/c291625f9a0f638a6d5009032047ac1534d1ef76/src/main/java/c4/comforts/api/ComfortsRegistry.java#L23-L25), and then use that in its sleep handler. That part is pretty straightforward.

The tricky part is that since this allows Comforts to do the correct filtering itself, we need to then make sure that the RandomTweaks sleep handler doesn't fire, but only for Comforts. The implementation in this PR exits the handler if the bed block is from Comforts (you could clean this up a little by using instanceof checks for the exact Comforts blocks, but that would require you to add Comforts as a library and I wasn't sure if you wanted to do that). This mostly works, but it does break the auto-sleep sleeping bag config option from Comforts. All things considered, I think that's an acceptable loss and I might be able to figure out a workaround eventually on my end. Until then, I can just disable that config option if RandomTweaks is loaded.

There's also one small fix that I wrote in the process of doing this. You were using AxisAlignedBB#expand, which is one-directional. The correct method is AxisAlignedBB#grow, which is omni-directional.

Please let me know if you'd like changes made, or if you know of a better method that we could implement. I'd like our mods to be as compatible as possible.