### PR TITLE
Update Comforts compatibility

### DIFF
--- a/src/main/java/com/therandomlabs/randomtweaks/common/SleepHandler.java
+++ b/src/main/java/com/therandomlabs/randomtweaks/common/SleepHandler.java
@@ -50,14 +50,6 @@ public final class SleepHandler {
 			return;
 		}
 
-		if(RandomTweaks.COMFORTS_LOADED) {
-			for(StackTraceElement element : Thread.currentThread().getStackTrace()) {
-				if(element.getClassName().equals("c4.comforts.common.items.ItemSleepingBag")) {
-					return;
-				}
-			}
-		}
-
 		final BlockPos pos = event.getPos();
 
 		IBlockState state;
@@ -69,7 +61,7 @@ public final class SleepHandler {
 			if(state != null) {
 				final ResourceLocation name = state.getBlock().getRegistryName();
 				
-				if(name != null && name.getNamespace().equals("comforts")) {
+				if(name != null && name.toString().startsWith("comforts:hammock")) {
 					return;
 				}
 


### PR DESCRIPTION
Hey, it's me again. The latest update for Comforts introduced a few changes that broke the compatibility I introduced last time. Specifically, the sleeping bag relegates all of its sleeping behavior to vanilla now so your mod can fully take over. This PR deletes the now unnecessary check for the sleeping bag item/block and limits the event skipping to only the hammocks. Everything else is still necessary to make the hammocks work.

One thing to possibly add is to update the optional dependencies to require the compatible version of Comforts (1.2.0) if present, since merging this PR means previous versions of Comforts will not work correctly anymore with RandomTweaks. That's what I would do, but I didn't want to mess with anything that I didn't have to for the moment.